### PR TITLE
chore(qemu): add QEMU version history

### DIFF
--- a/org.virt_manager.virt_manager.Extension.Qemu.metainfo.xml
+++ b/org.virt_manager.virt_manager.Extension.Qemu.metainfo.xml
@@ -8,10 +8,81 @@
   <summary>Generic machine emulator and virtualizer and utilities for virtual machines</summary>
   <url type="homepage">https://qemu.org/</url>
   <releases>
-    <release version="9.2.0" date="2024-12-10"/>
-    <release version="9.1.2" date="2024-11-20"/>
-    <release version="9.0.4" date="2024-11-20"/>
-    <release version="8.2.8" date="2024-11-20"/>
-    <release version="7.2.15" date="2024-11-20"/>
+    <release version="11.0.0" date="2026-04-21" /> 
+    <release version="11.0.0" date="2026-05-10" />
+    <release version="10.2.2" date="2026-03-17" />
+    <release version="10.2.2" date="2026-03-17" /> 
+    <release version="10.2.1" date="2026-02-12" /> 
+    <release version="10.2.0" date="2025-12-23" /> 
+    <release version="10.2.0" date="2025-12-23" />
+    <release version="10.1.5" date="2026-03-17" /> 
+    <release version="10.1.5" date="2026-03-17" />
+    <release version="10.1.4" date="2026-02-12" /> 
+    <release version="10.1.4" date="2026-02-12" />
+    <release version="10.1.3" date="2025-12-05" />
+    <release version="10.1.3" date="2025-12-05" /> 
+    <release version="10.1.2" date="2025-10-20" /> 
+    <release version="10.1.1" date="2025-10-08" /> 
+    <release version="10.1.0" date="2025-08-26" /> 
+    <release version="10.0.9" date="2026-03-17" /> 
+    <release version="10.0.9" date="2026-03-17" />
+    <release version="10.0.8" date="2026-02-12" />
+    <release version="10.0.8" date="2026-02-12" /> 
+    <release version="10.0.7" date="2025-12-05" /> 
+    <release version="10.0.7" date="2025-12-05" />
+    <release version="10.0.6" date="2025-10-20" /> 
+    <release version="10.0.5" date="2025-10-08" /> 
+    <release version="10.0.4" date="2025-09-08" /> 
+    <release version="10.0.3" date="2025-07-22" /> 
+    <release version="10.0.2" date="2025-05-28" /> 
+    <release version="10.0.1" date="2025-05-26" /> 
+    <release version="10.0.0" date="2025-04-22" /> 
+    <release version="9.2.4" date="2025-05-26" /> 
+    <release version="9.2.3" date="2025-03-26" /> 
+    <release version="9.2.2" date="2025-02-24" /> 
+    <release version="9.2.1" date="2025-02-08" /> 
+    <release version="9.2.0" date="2024-12-10" />
+    <release version="9.2.0" date="2024-12-10" /> 
+    <release version="9.1.2" date="2024-11-21" /> 
+    <release version="9.1.2" date="2024-11-20" />
+    <release version="9.1.1" date="2024-10-18" /> 
+    <release version="9.1.0" date="2025-02-08" /> 
+    <release version="9.1.0" date="2024-09-03" /> 
+    <release version="9.0.4" date="2024-11-21" /> 
+    <release version="9.0.4" date="2024-11-20" />
+    <release version="9.0.3" date="2024-09-18" /> 
+    <release version="9.0.2" date="2024-07-16" /> 
+    <release version="9.0.1" date="2024-06-09" /> 
+    <release version="9.0.0" date="2024-04-23" /> 
+    <release version="8.2.9" date="2025-02-08" /> 
+    <release version="8.2.8" date="2024-11-21" /> 
+    <release version="8.2.8" date="2024-11-20" />
+    <release version="8.2.7" date="2024-09-18" /> 
+    <release version="8.2.6" date="2024-07-16" /> 
+    <release version="8.2.5" date="2024-06-09" /> 
+    <release version="8.2.4" date="2024-05-13" /> 
+    <release version="8.2.3" date="2024-04-24" /> 
+    <release version="8.2.2" date="2024-03-04" /> 
+    <release version="8.2.1" date="2025-03-26" /> 
+    <release version="8.2.1" date="2024-01-29" /> 
+    <release version="8.2.0" date="2023-12-19" /> 
+    <release version="8.1.5" date="2024-01-29" /> 
+    <release version="8.1.4" date="2023-12-22" /> 
+    <release version="7.2.9" date="2024-01-29" /> 
+    <release version="7.2.8" date="2023-12-22" /> 
+    <release version="7.2.22" date="2025-12-05" /> 
+    <release version="7.2.21" date="2025-10-08" /> 
+    <release version="7.2.20" date="2025-09-08" /> 
+    <release version="7.2.19" date="2025-07-22" /> 
+    <release version="7.2.18" date="2025-05-26" /> 
+    <release version="7.2.17" date="2025-03-26" /> 
+    <release version="7.2.16" date="2025-02-08" /> 
+    <release version="7.2.15" date="2024-11-21" /> 
+    <release version="7.2.15" date="2024-11-20" />
+    <release version="7.2.14" date="2024-09-18" /> 
+    <release version="7.2.13" date="2024-07-16" /> 
+    <release version="7.2.12" date="2024-06-09" /> 
+    <release version="7.2.11" date="2024-04-24" /> 
+    <release version="7.2.10" date="2024-03-04" /> 
   </releases>
 </component>


### PR DESCRIPTION
This was done in an automated manner, might be wrong in a few places maybe? Using the Github API.

